### PR TITLE
Fix profilepath ascompany

### DIFF
--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -147,8 +147,12 @@
     <h1>Artist? Start exposing now!</h1>
     <p> Join our community and get selected to exhibit your creations in the best offices</p>
     <% if user_signed_in? %>
-      <%= link_to "start experience", artist_users_path(current_user), class: "btn btn-primary btn-lg" %>
+      <% if current_user.is_company %>
+        <%= link_to "start experience", root_path, class: "btn btn-primary btn-lg" %>
       <% else %>
+        <%= link_to "start experience", exhibitions_path, class: "btn btn-primary btn-lg" %>
+      <% end %>
+    <% else %>
       <%= link_to "start experience", new_user_session_path, class: "btn btn-primary btn-lg" %>
     <% end %>
   </div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -9,13 +9,13 @@
 
     <!-- Different navigation if login or not -->
     <% if user_signed_in? %>
-
       <!-- Profile picture and dropdown -->
       <div class="navbar-wagon-item">
         <div class="dropdown">
           <%= image_tag "http://placehold.it/30x30", class: "avatar dropdown-toggle", id: "navbar-wagon-menu", "data-toggle" => "dropdown" %>
           <ul class="dropdown-menu dropdown-menu-right navbar-wagon-dropdown-menu">
-             <li>
+
+            <li>
               <% if policy(current_user).dashboard_company? %>
                 <%= link_to dashboard_company_users_path do %>
                   <i class="fa fa-user"></i> <%= t(".dashboard", default: "Dashboard") %>
@@ -26,22 +26,31 @@
                 <% end %>
               <% end %>
             </li>
+
             <li>
-            <li>
-              <%= link_to artist_users_path(current_user) do %>
-                <i class="fa fa-user"></i> <%= t(".profile", default: "Profile") %>
+              <% if policy(current_user).dashboard_company? %>
+                <%= link_to root_path do %>
+                  <i class="fa fa-user"></i> <%= t(".profile", default: "Profile") %>
+                <% end %>
+              <% else %>
+                <%= link_to artist_users_path(current_user) do %>
+                  <i class="fa fa-user"></i> <%= t(".profile", default: "Profile") %>
+                <% end %>
               <% end %>
             </li>
+
             <li>
               <%= link_to root_path do %>
                 <i class="fa fa-home"></i>  <%= t(".profile", default: "Home") %>
               <% end %>
             </li>
+
             <li>
               <%= link_to destroy_user_session_path, method: :delete do %>
                 <i class="fa fa-sign-out"></i>  <%= t(".sign_out", default: "Log out") %>
               <% end %>
             </li>
+
           </ul>
         </div>
       </div>


### PR DESCRIPTION
Petit fix pour que l'icone profile dans navbar  + bouton start experience route bien en fonction de si je suis logged ou pas et en fonction de si je suis company vs artist.

je l'ai teste dans les 3 cas de figures, pas de bugs.

Quand on est une compagnie, j'ai route vers la homepage pour pas que pendant el demoday on fasse l'erreur de cliquer dessus pas erreur.